### PR TITLE
feat: max wait for load

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ You can choose from two ways of running audits - "locally" in a dockerized envir
     <td><code>undefined</code></td>
   </tr>
   <tr>
+    <td><code>maxWaitForLoad</code></td>
+    <td>The maximum amount of time to wait for a page to load in ms.</td>
+    <td><code>number</code></td>
+    <td><code>local</code></td>
+    <td><code>undefined</code></td>
+  </tr>
+  <tr>
     <td><code>pr</code></td>
     <td>For Slack notifications: A version control pull request URL, typically from GitHub.</td>
     <td><code>string</code></td>

--- a/src/commands/audit.yml
+++ b/src/commands/audit.yml
@@ -41,6 +41,10 @@ parameters:
     description: A locale for Lighthouse reports. Example - ja
     type: string
     default: ""
+  maxWaitForLoad:
+    description: The maximum amount of time to wait for a page to load in ms
+    type: integer
+    default: 45000
   pr:
     description: For Slack notifications - A version control pull request URL, typically from GitHub.
     type: string
@@ -102,6 +106,7 @@ steps:
           --configFile << parameters.configFile >> \
           --emulatedFormFactor << parameters.emulatedFormFactor >> \
           --locale << parameters.locale >> \
+          --maxWaitForLoad << parameters.maxWaitForLoad >> \
           --outputDirectory /tmp/artifacts \
           --pr << parameters.pr >> \
           --prCommentAccessToken << parameters.prCommentAccessToken >> \


### PR DESCRIPTION
By exposing Lighthouse's [`max-wait-for-load` option](https://github.com/GoogleChrome/lighthouse#cli-options), perhaps we can help prevent protocol timeout errors as described in [issue #10 of the `@foo-software/lighthouse-check` project](https://github.com/foo-software/lighthouse-check/issues/10).